### PR TITLE
Added response if container is down

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -5,7 +5,9 @@
     "httpPort": 8080,
     "tcpPort": 8081,
     "udpPort": 8082,
-    "isLeader": true
+    "isLeader": false,
+    "isUp": false
+
   },
   "peers": [
     {
@@ -14,7 +16,9 @@
       "httpPort": 8070,
       "tcpPort": 8071,
       "udpPort": 8072,
-      "isLeader": false
+      "isLeader": false,
+      "isUp": false
+
     },
     {
       "id": 3,
@@ -22,7 +26,9 @@
       "httpPort": 8090,
       "tcpPort": 8091,
       "udpPort": 8092,
-      "isLeader": false
+      "isLeader": false,
+      "isUp": false
+
     }
   ],
   "tu": 5000

--- a/config1/config.json
+++ b/config1/config.json
@@ -5,7 +5,9 @@
     "httpPort": 8070,
     "tcpPort": 8071,
     "udpPort": 8072,
-    "isLeader": false
+    "isLeader": false,
+    "isUp": false
+
   },
   "peers": [
     {
@@ -14,7 +16,9 @@
       "httpPort": 8080,
       "tcpPort": 8081,
       "udpPort": 8082,
-      "isLeader": true
+      "isLeader": false,
+      "isUp": false
+
     },
     {
       "id": 3,
@@ -22,7 +26,9 @@
       "httpPort": 8090,
       "tcpPort": 8091,
       "udpPort": 8092,
-      "isLeader": false
+      "isLeader": false,
+      "isUp": false
+
     }
   ],
   "tu": 10000

--- a/config2/config.json
+++ b/config2/config.json
@@ -5,7 +5,9 @@
     "httpPort": 8090,
     "tcpPort": 8091,
     "udpPort": 8092,
-    "isLeader": false
+    "isLeader": false,
+    "isUp": false
+
   },
   "peers": [
     {
@@ -14,7 +16,8 @@
       "httpPort": 8070,
       "tcpPort": 8071,
       "udpPort": 8072,
-      "isLeader": false
+      "isLeader": false,
+      "isUp": false
     },
     {
       "id": 1,
@@ -22,7 +25,8 @@
       "httpPort": 8080,
       "tcpPort": 8081,
       "udpPort": 8082,
-      "isLeader": true
+      "isLeader": false,
+      "isUp": false
     }
   ],
   "tu": 8000

--- a/src/main/kotlin/com/example/Models.kt
+++ b/src/main/kotlin/com/example/Models.kt
@@ -5,4 +5,32 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Instance(var self:Node, var peers:ArrayList<Node>, var tu:Int)
 @Serializable
-data class Node(var id: Int, var address: String, var httpPort: Int, val tcpPort: Int, var udpPort: Int, var isLeader:Boolean)
+data class Node(var id: Int, var address: String, var httpPort: Int, val tcpPort: Int, var udpPort: Int, var isLeader:Boolean, var isUp:Boolean)
+
+@Serializable
+data class Message(var type: MessageType, var content:String)
+
+@Serializable
+data class  DataList(var data_id:Int, var node_list:ArrayList<Data>)
+@Serializable
+data class Data(var id:Int, var content:String, var modificationTime : Long)
+@Serializable
+enum class MessageType{
+    leaderRequest, //Asks if is leader
+    leaderResponse, //Sends self isLeader status
+    dataSend, //Sends data over tcp from http server or to a server in case of a serverDownAlert
+    dataSendRequest, //Asks server to send a specific data to originator based on id
+    dataSync, //Sends all data from server for synchronization purposes
+    serverDownAlertActive, //Sends notification that one of the servers isn't responding. Forces the servers to pick up its data
+    serverDownAlertPassive, //Sends notification that a server is down
+    locationSync, //Syncronizes map with data location. Sent through UDP by leader
+    updateLocations //Sent to leader to ask to add the server to the dataLocations of those datas
+}
+
+@Serializable
+data class LeaderMessage(val id: Int, val isLeader: Boolean)
+
+@Serializable
+data class SyncronizeLocationrequest(var dataLocation : HashMap<Int, ArrayList<Int>>)
+@Serializable
+data class UpdateLocationRequest(val id: Int, val datas: ArrayList<Int>)


### PR DESCRIPTION
Corrected minor issues with TCP connection. 

Added fault tolerance. If a container doesnt receive TCP connection and throws an Undeclared Address error, the container making the request notifies everyone that the server is done. To fit the number required by fault tolerance, the x number of containers receive a serverDownAlertActive and the rest receive a passive alert. The active forces them to check which data that previously belonged to the dead server they can grab, then to find and notify the current leader to write them into the location list. The leader will add them, then all servers will receive the updated list, based on which they will later synchronize with each other to update the data. The passive just marks the container as dead so it doesnt receive TCP requests.